### PR TITLE
Configuration

### DIFF
--- a/kanelbulle/config/__init__.py
+++ b/kanelbulle/config/__init__.py
@@ -1,0 +1,1 @@
+"""Modules related to config"""

--- a/kanelbulle/config/config.py
+++ b/kanelbulle/config/config.py
@@ -1,0 +1,32 @@
+"""Configuration storage."""
+
+import json
+
+
+class Container:
+    """Load and store configurations.
+
+    Attributes:
+        data: configuration data (dict).
+        error: error message (str).
+    """
+
+    def __init__(self):
+        self.data = None
+        self.error = "No error"
+        self.load()
+
+    def load(self):
+        """Load configurations from file."""
+        try:
+            with open("arms/config/config.json", 'r') as stream:
+                self.data = json.load(stream)
+        except OSError as e:
+            self.data = None
+            self.error = "OSError - " + str(e)
+        except ValueError as e:
+            self.data = None
+            self.error = "ValueError - " + str(e)
+
+
+var = Container()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,35 @@
+"""Tests for kanelbulle.config.config."""
+
+from unittest import mock
+from kanelbulle.config import config
+
+
+def test_var_is_container():
+    """The variable var shall be an instance of the class Container."""
+    assert isinstance(config.var, config.Container) == True
+
+
+@mock.patch.object(config, 'open')
+def test_load_os_error(mock_open):
+    """IF a system-related error occurs, WHEN the configuration file is
+    loaded, THEN the respective error message shall be stored and the data
+    field shall be empty.
+    """
+    mock_open.side_effect = OSError
+    config.var.data = "OSError"
+    config.var.load()
+    assert (config.var.data is None) == True
+    assert ("OSError" in config.var.error) == True
+
+
+@mock.patch.object(config, 'open')
+def test_load_value_error(mock_open):
+    """IF a value error occurs, WHEN the configuration file is
+    loaded, THEN the respective error message shall be stored and the data
+    field shall be empty.
+    """
+    mock_open.side_effect = ValueError
+    config.var.data = "ValueError"
+    config.var.load()
+    assert (config.var.data is None) == True
+    assert ("ValueError" in config.var.error) == True


### PR DESCRIPTION
Issue: #4.

This adds a new class named _Container_, which reads _kanelbulle/config/config.json_ and stores the content in its attribute _data_. If an error occurs, the data field is emptied and the error message is stored. 

Three unit tests check if the class fulfills the following requirements:
- The variable _var_ shall be an instance of the class _Container_.
- IF a system-related error occurs, WHEN the configuration file is loaded, THEN the respective error message shall be stored and the data field shall be empty.
- IF a value error occurs, WHEN the configuration file is loaded, THEN the respective error message shall be stored and the data field shall be empty.

Closes #4.
